### PR TITLE
Fix embed URL generation

### DIFF
--- a/app/controllers/EmbedsController.php
+++ b/app/controllers/EmbedsController.php
@@ -14,6 +14,13 @@ use App\Services\MemeRenderer;
 
 class EmbedsController extends Controller
 {
+    protected string $baseUrl;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->baseUrl = rtrim(_env('APP_URL'), '/');
+    }
 
 
     public function generateEmbeddings()
@@ -107,7 +114,7 @@ class EmbedsController extends Controller
 
 
         response()->json([
-            'image_url' => '/generated/' . basename($outputPath),
+            'image_url' => $this->baseUrl . '/generated/' . basename($outputPath),
             'caption' => $caption,
             'meme_id' => $bestMeme->id,
             'score' => $bestScore
@@ -135,7 +142,7 @@ class EmbedsController extends Controller
         ]);
 
         response()->json([
-            'image_url' => 'https://dankterminal.xyz/generated/' . basename($outputPath),
+            'image_url' => $this->baseUrl . '/generated/' . basename($outputPath),
             'caption' => $caption,
             'meme_id' => $meme->id
         ]);
@@ -211,7 +218,7 @@ class EmbedsController extends Controller
         ]);
 
         response()->json([
-            'image_url' => '/generated/' . basename($outputPath),
+            'image_url' => $this->baseUrl . '/generated/' . basename($outputPath),
             'caption' => $caption,
             'meme_id' => $meme->id
         ]);


### PR DESCRIPTION
## Summary
- use `APP_URL` env for embedding results
- return absolute URLs for meme generation

## Testing
- `php -l app/controllers/EmbedsController.php`


------
https://chatgpt.com/codex/tasks/task_e_688271fbcdfc8333a8c623cc995e92c9