### PR TITLE
Use APP_URL for dynamic meme URL

### DIFF
--- a/app/controllers/EmbedsController.php
+++ b/app/controllers/EmbedsController.php
@@ -134,8 +134,10 @@ class EmbedsController extends Controller
             'caption' => $caption
         ]);
 
+        $baseUrl = rtrim(_env('APP_URL'), '/');
+
         response()->json([
-            'image_url' => 'https://dankterminal.xyz/generated/' . basename($outputPath),
+            'image_url' => $baseUrl . '/generated/' . basename($outputPath),
             'caption' => $caption,
             'meme_id' => $meme->id
         ]);


### PR DESCRIPTION
## Summary
- fetch `APP_URL` and use it in `generateFromRandom` so image URLs are built dynamically

## Testing
- `php -l app/controllers/EmbedsController.php`

------
https://chatgpt.com/codex/tasks/task_e_688271fcba60833391efe4c196784377