### PR TITLE
Use APP_URL in TelegramService

### DIFF
--- a/app/services/TelegramService.php
+++ b/app/services/TelegramService.php
@@ -10,6 +10,7 @@ class TelegramService
     private string $apiUrl;
     private Client $client;
     private Client $appClient;
+    private string $baseUrl;
 
     public function __construct()
     {
@@ -24,7 +25,8 @@ class TelegramService
 
         ]);
 
-        $appUrl = rtrim(_env('APP_URL'), '/') . '/';
+        $this->baseUrl = rtrim(_env('APP_URL'), '/');
+        $appUrl = $this->baseUrl . '/';
         $this->appClient = new Client([
             'base_uri' => $appUrl,
             'timeout' => 10,
@@ -93,9 +95,12 @@ class TelegramService
     public function callGenerateEndpoint(string $prompt): ?array
     {
         try {
-            $response = $this->appClient->post('memes/generate', [
-                'form_params' => ['prompt' => $prompt],
-            ]);
+            $response = $this->appClient->post(
+                $this->baseUrl . '/memes/generate',
+                [
+                    'form_params' => ['prompt' => $prompt],
+                ]
+            );
 
             return json_decode($response->getBody(), true);
         } catch (RequestException $e) {
@@ -108,7 +113,10 @@ class TelegramService
         try {
             $payload = $imageId ? ['form_params' => ['image_id' => $imageId]] : [];
 
-            $response = $this->appClient->post('memes/creative', $payload);
+            $response = $this->appClient->post(
+                $this->baseUrl . '/memes/creative',
+                $payload
+            );
 
             return json_decode($response->getBody(), true);
         } catch (RequestException $e) {


### PR DESCRIPTION
## Summary
- store base app URL once in `TelegramService`
- build meme endpoints from the configured URL

## Testing
- `php -l app/services/TelegramService.php`


------
https://chatgpt.com/codex/tasks/task_e_68827af0413c83338f1e6e58e2280221