### PR TITLE
Handle invalid image IDs for creative command

### DIFF
--- a/app/controllers/EmbedsController.php
+++ b/app/controllers/EmbedsController.php
@@ -192,7 +192,7 @@ class EmbedsController extends Controller
             $imageId = reset($imageId);
         }
 
-        if (!empty($imageId)) {
+        if (!empty($imageId) && is_numeric($imageId)) {
             return $this->generateFromImageId($imageId);
         } else {
             return $this->generateFromRandom();

--- a/app/controllers/TelegramsController.php
+++ b/app/controllers/TelegramsController.php
@@ -88,8 +88,12 @@ class TelegramsController extends Controller
 
             // /creative
             if (stripos($text, '/creative') === 0) {
-                $parts = explode(' ', $text);
+                $parts = preg_split('/\s+/', $text);
                 $imageId = $parts[1] ?? null;
+
+                if ($imageId !== null && !ctype_digit($imageId)) {
+                    $imageId = null;
+                }
 
                 $response = $telegram->callCreativeEndpoint($imageId);
                 file_put_contents('tg.log', "\n\nCREATIVE RESPONSE:\n" . json_encode($response, JSON_PRETTY_PRINT) . "\n", FILE_APPEND);


### PR DESCRIPTION
## Summary
- sanitize /creative command to ignore non-numeric image IDs
- validate image_id before generating a creative meme

## Testing
- `composer validate --no-check-all --strict`
- `php -l app/controllers/TelegramsController.php`
- `php -l app/controllers/EmbedsController.php`


------
https://chatgpt.com/codex/tasks/task_e_68827c73bfc08333b4c383334e83361a